### PR TITLE
adding client ID to retrieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,18 @@ var SoapClient = new FuelSoap( options );
 ## Examples
 
 ```js
-var filter = {
-    leftOperand: 'Name',
-    operator: 'equals',
-    rightOperand: 'Test Email'
+var options = {
+	filter: {
+		leftOperand: 'Name',
+		operator: 'equals',
+		rightOperand: 'Test Email'
+	}
 };
 
 SoapClient.retrieve(
     'Email',
     ["ID", "Name", "Subject", "CategoryID", "EmailType"],
-    filter,
+    {"options":options},
     function( err, response ) {
         if ( err ) {
             // error here
@@ -79,6 +81,34 @@ SoapClient.retrieve(
         // response.res === full response from request client
         console.log( response.body );
     }
+);
+```
+##Example with specifying business unit
+```js
+var options = {
+	filter: {
+		leftOperand: 'Name',
+		operator: 'equals',
+		rightOperand:  'Test Folder'
+	},
+	clientIDs: [{ID:12345}]
+};
+
+SoapClient.retrieve(
+	'DataFolder',
+	["ID"],
+	{"options":options},
+	function( err, response ) {
+		if ( err ) {
+			// error here
+			console.log( err );
+			return;
+		}
+
+		// response.body === parsed soap response (JSON)
+		// response.res === full response from request client
+		console.log(response.body);
+	}
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ SoapClient.retrieve(
 * Aydrian J. Howard - [twitter](https://twitter.com/aydrianh), [github](https://github.com/aydrian)
 * Alex Vernacchia - [twitter](https://twitter.com/vernacchia), [github](https://github.com/vernak2539)
 * Kelly Andrews - [twitter](https://twitter.com/kellyjandrews), [github](https://github.com/kellyjandrews)
+* Jimmy Burgess - [github](https://github.com/jimmyburgess91)
 
 ## Contributing
 

--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -197,34 +197,23 @@ FuelSoap.prototype.retrieve = function (type, props, options, callback) {
 		filter = options.filter;
 		clientIDs = options.clientIDs;
 	}
-
+	
+	var body = {
+		'RetrieveRequestMsg': {
+			'$': {
+				'xmlns': 'http://exacttarget.com/wsdl/partnerAPI'
+			},
+			'RetrieveRequest': {
+				'ObjectType': type,
+				'Properties': props
+			}
+		}
+	};
+	
 	//TO-DO How to handle casing with properties?
 	if(clientIDs) {
-		var body = {
-			'RetrieveRequestMsg': {
-				'$': {
-					'xmlns': 'http://exacttarget.com/wsdl/partnerAPI'
-				},
-				'RetrieveRequest': {
-					'ObjectType': type,
-					'Properties': props,
-					'ClientIDs': clientIDs
-				}
-			}
-		};
-	} else {
-		var body = {
-			'RetrieveRequestMsg': {
-				'$': {
-					'xmlns': 'http://exacttarget.com/wsdl/partnerAPI'
-				},
-				'RetrieveRequest': {
-					'ObjectType': type,
-					'Properties': props
-				}
-			}
-		};
-	}
+		body.RetrieveRequestMsg.RetrieveRequest.ClientIDs = clientIDs;
+	} 
 
 	// filter can be simple or complex and has three properties leftOperand, rightOperand, and operator
 	if (filter) {

--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2014​, salesforce.com, inc.
+* Copyright (c) 2014?, salesforce.com, inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided
@@ -163,44 +163,68 @@ FuelSoap.prototype.create = function (type, props, options, callback) {
 	}, callback);
 };
 
-FuelSoap.prototype.retrieve = function (type, props, filter, callback) {
+FuelSoap.prototype.retrieve = function (type, props, options, callback) {
 	var defaultProps = ['Client', 'ID', 'ObjectID'];
-
+	var filter = null;
+	var clientIDs =  null;
 	if (arguments.length < 4) {
-		//if props and filter are not included
+		//if props and options are not included
 		if (Object.prototype.toString.call(arguments[1]) === "[object Function]") {
 			callback = props;
 			filter = null;
+			options = null;
+			clientIDs = null;
 			props = defaultProps;
 		}
 
-		//if props or filter is included
+		//if props or options is included
 		if (Object.prototype.toString.call(arguments[2]) === "[object Function]") {
 
-			callback = filter;
+			callback = options;
 			//check if props or filter
 			if (Object.prototype.toString.call(arguments[1]) === "[object Object]") {
-				filter = props;
+				filter = options.filter;
+				clientIDs = options.clientIDs;
 				props = defaultProps;
 			} else {
 				filter = null;
+				options = null;
+				clientIDs =  null;
 			}
 		}
 	}
+	else {
+		filter = options.filter;
+		clientIDs = options.clientIDs;
+	}
 
 	//TO-DO How to handle casing with properties?
-
-	var body = {
-		'RetrieveRequestMsg': {
-			'$': {
-				'xmlns': 'http://exacttarget.com/wsdl/partnerAPI'
-			},
-			'RetrieveRequest': {
-				'ObjectType': type,
-				'Properties': props
+	if(clientIDs) {
+		var body = {
+			'RetrieveRequestMsg': {
+				'$': {
+					'xmlns': 'http://exacttarget.com/wsdl/partnerAPI'
+				},
+				'RetrieveRequest': {
+					'ObjectType': type,
+					'Properties': props,
+					'ClientIDs': clientIDs
+				}
 			}
-		}
-	};
+		};
+	} else {
+		var body = {
+			'RetrieveRequestMsg': {
+				'$': {
+					'xmlns': 'http://exacttarget.com/wsdl/partnerAPI'
+				},
+				'RetrieveRequest': {
+					'ObjectType': type,
+					'Properties': props
+				}
+			}
+		};
+	}
 
 	// filter can be simple or complex and has three properties leftOperand, rightOperand, and operator
 	if (filter) {

--- a/lib/fuel-soap.js
+++ b/lib/fuel-soap.js
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2014?, salesforce.com, inc.
+* Copyright (c) 2015, salesforce.com, inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted provided

--- a/test/specs/function-soap-methods.js
+++ b/test/specs/function-soap-methods.js
@@ -137,7 +137,7 @@ describe( 'SOAP methods', function() {
 		});
 	});
 	
-		describe( 'retrieve', function () {
+	describe( 'retrieve', function () {
 		it( 'should deliver a retrieve + response', function(done) {
 			// setting up spy and soap client
 			var soapRequestSpy = sinon.spy( FuelSoap.prototype, 'soapRequest' );

--- a/test/specs/function-soap-methods.js
+++ b/test/specs/function-soap-methods.js
@@ -116,6 +116,68 @@ describe( 'SOAP methods', function() {
 					"ModifiedDate"
 				],
 				{
+					filter: {
+						leftOperand: 'Name',
+						operator: 'equals',
+						rightOperand: 'DS_TEST'
+					},
+					clientIDs: [{ID:6227021}]
+				},
+				function( err, data ) {
+					// need to make sure we called soapRequest method
+					expect( soapRequestSpy.calledOnce ).to.be.true;
+
+					// making sure original request was retrieve
+					expect( data.res.req._headers.soapaction.toLowerCase() ).to.equal( 'retrieve' );
+
+					FuelSoap.prototype.soapRequest.restore(); // restoring function
+					done();
+				}
+			);
+		});
+	});
+	
+		describe( 'retrieve', function () {
+		it( 'should deliver a retrieve + response', function(done) {
+			// setting up spy and soap client
+			var soapRequestSpy = sinon.spy( FuelSoap.prototype, 'soapRequest' );
+
+			// initialization options
+			var options = {
+				auth: {
+					clientId: 'testing'
+					, clientSecret: 'testing'
+				}
+				, soapEndpoint: localhost
+			};
+			var SoapClient = new FuelSoap( options );
+
+			// faking auth
+			SoapClient.AuthClient.accessToken = 'testForSoap';
+			SoapClient.AuthClient.expiration  = 111111111111;
+
+			SoapClient.retrieve(
+				'Email',
+				[
+					"ID",
+					"Client.ID",
+					"Name",
+					"CategoryID",
+					"HTMLBody",
+					"TextBody",
+					"Subject",
+					"IsActive",
+					"IsHTMLPaste",
+					"EmailType",
+					"CharacterSet",
+					"HasDynamicSubjectLine",
+					"ContentCheckStatus",
+					"ContentAreas",
+					"CustomerKey",
+					"CreatedDate",
+					"ModifiedDate"
+				],
+				{
 					leftOperand: 'Name',
 					operator: 'equals',
 					rightOperand: 'DS_TEST'


### PR DESCRIPTION
I've modified the retrieve function signature to replace the filter param with an options param.  This options param allows you to specify the clientID (business unit) on retrieve requests.  This pertains to the issue at https://github.com/ExactTarget/Fuel-Node-SOAP/issues/45.